### PR TITLE
adding schemas for bound points

### DIFF
--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -48,6 +48,11 @@ from emannotationschemas.schemas.fly_cell_types import FlyCellType, FlyCellTypeE
 from emannotationschemas.schemas.braincircuits import (
     BrainCircuitsBoundTagAnnotationUser,
 )
+from emannotationschemas.schemas.bound_bool_tag import (
+    BoundBoolAnnotation,
+    BoundBoolWithValid,
+    BoundTagWithValid,
+)
 
 from emannotationschemas.errors import UnknownAnnotationTypeException
 from emannotationschemas.flatten import create_flattened_schema
@@ -94,8 +99,10 @@ type_mapping = {
     "fly_cell_type": FlyCellType,
     "fly_cell_type_ext": FlyCellTypeExt,
     "braincircuits_annotation_user": BrainCircuitsBoundTagAnnotationUser,
+    "bound_tag_bool": BoundBoolAnnotation,
+    "bound_tag_bool_valid": BoundBoolWithValid,
+    "bound_tag_valid": BoundTagWithValid,
 }
-
 
 def get_types():
     return [k for k in type_mapping.keys()]

--- a/emannotationschemas/schemas/bound_bool_tag.py
+++ b/emannotationschemas/schemas/bound_bool_tag.py
@@ -1,0 +1,23 @@
+import marshmallow as mm
+from emannotationschemas.schemas.base import AnnotationSchema, BoundSpatialPoint, NumericField
+from emannotationschemas.schemas.bound_text_tag import BoundTagAnnotation
+
+class BoundBoolAnnotation(AnnotationSchema):
+    pt = mm.fields.Nested(
+        BoundSpatialPoint, 
+        required=True, 
+        description="Location associated with the tag"
+    )
+    tag = mm.fields.Bool(required=True, description="Boolean at location")
+
+class BoundBoolWithValid(BoundBoolAnnotation):
+    valid_id = NumericField(
+        required=True,
+        description="Root id of the object when location was assessed. If the pt_root_id has changed, the associated segment has undergone proofreading.",
+    )
+
+class BoundTagWithValid(BoundTagAnnotation):
+    valid_id = NumericField(
+        required=True,
+        description="Root id of the object when location was assessed. If the pt_root_id has changed, the associated segment has undergone proofreading.",
+    )


### PR DESCRIPTION
Adds 3 schemas for bound spatial points: boolean tag; boolean tag with valid reference id; string tag with valid reference id. Related to Vortex myelin annotations