### PR TITLE
added reference tag type

### DIFF
--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -59,6 +59,9 @@ from emannotationschemas.schemas.bound_bool_tag import (
     BoundBoolWithValid,
     BoundTagWithValid,
 )
+from emannotationschemas.schemas.reference_text_float import (
+    ReferenceTagFloat,
+)
 
 from emannotationschemas.errors import UnknownAnnotationTypeException
 from emannotationschemas.flatten import create_flattened_schema
@@ -111,6 +114,7 @@ type_mapping = {
     "bound_tag_bool_valid": BoundBoolWithValid,
     "bound_tag_valid": BoundTagWithValid,
     "reference_integer": ReferenceInteger,
+    "reference_tag_float": ReferenceTagFloat,
 }
 
 

--- a/emannotationschemas/schemas/reference_text_float.py
+++ b/emannotationschemas/schemas/reference_text_float.py
@@ -1,0 +1,10 @@
+import marshmallow as mm
+from emannotationschemas.schemas.base import (
+    ReferenceTagAnnotation,
+)
+
+class ReferenceTagFloat(ReferenceTagAnnotation):
+    value = mm.fields.Float(
+        required=True, desription="Float value to be attached to the annotation"
+    )
+    


### PR DESCRIPTION
adding a reference tag with a float field. Specifically to make a reference annotation on the nucleus table to describe brain area (string) and distance (float). 