### PR TITLE
Add proofreading schema

### DIFF
--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -58,6 +58,7 @@ from emannotationschemas.schemas.bound_bool_tag import (
     BoundBoolAnnotation,
     BoundBoolWithValid,
     BoundTagWithValid,
+    SpatialPointBoolWithValid,
 )
 from emannotationschemas.schemas.reference_text_float import (
     ReferenceTagFloat,
@@ -113,6 +114,7 @@ type_mapping = {
     "bound_tag_bool": BoundBoolAnnotation,
     "bound_tag_bool_valid": BoundBoolWithValid,
     "bound_tag_valid": BoundTagWithValid,
+    "pt_bool_valid": SpatialPointBoolWithValid,
     "reference_integer": ReferenceInteger,
     "reference_tag_float": ReferenceTagFloat,
 }

--- a/emannotationschemas/__init__.py
+++ b/emannotationschemas/__init__.py
@@ -47,6 +47,7 @@ from emannotationschemas.schemas.proofreading import (
     CompartmentProofreadStatus,
     ProofreadStatus,
     ProofreadingBoolStatusUser,
+    CompartmentProofreadStatusStrategy,
 )
 from emannotationschemas.schemas.neuropil import FlyNeuropil
 from emannotationschemas.schemas.groups import SimpleGroup
@@ -117,6 +118,7 @@ type_mapping = {
     "pt_bool_valid": SpatialPointBoolWithValid,
     "reference_integer": ReferenceInteger,
     "reference_tag_float": ReferenceTagFloat,
+    "compartment_proofread_status_strategy": CompartmentProofreadStatusStrategy,
 }
 
 

--- a/emannotationschemas/schemas/bound_bool_tag.py
+++ b/emannotationschemas/schemas/bound_bool_tag.py
@@ -1,5 +1,5 @@
 import marshmallow as mm
-from emannotationschemas.schemas.base import AnnotationSchema, BoundSpatialPoint, NumericField
+from emannotationschemas.schemas.base import AnnotationSchema, BoundSpatialPoint, NumericField, SpatialPoint
 from emannotationschemas.schemas.bound_text_tag import BoundTagAnnotation
 
 class BoundBoolAnnotation(AnnotationSchema):
@@ -20,4 +20,17 @@ class BoundTagWithValid(BoundTagAnnotation):
     valid_id = NumericField(
         required=True,
         description="Root id of the object when location was assessed. If the pt_root_id has changed, the associated segment has undergone proofreading.",
+    )
+
+class SpatialPointBoolWithValid(AnnotationSchema):
+    pt = mm.fields.Nested(
+        SpatialPoint, 
+        required=True, 
+        description="Location associated with the tag"
+    )
+    tag = mm.fields.Bool(required=True, description="Boolean at location")
+    
+    valid_id = NumericField(
+        required=True,
+        description="Root id of the object when location was assessed.",
     )

--- a/emannotationschemas/schemas/proofreading.py
+++ b/emannotationschemas/schemas/proofreading.py
@@ -54,3 +54,21 @@ class ProofreadingBoolStatusUser(ProofreadingBoolStatus):
         required=True,
         description="User who assessed the proofreading status.",
     )
+
+class CompartmentProofreadStatusStrategy(PointWithValid):
+    status_dendrite = fields.Bool(
+        required=True,
+        description=f"Proofread status of the dendrite only. True indicates dendrite is at least clean.",
+    )
+    status_axon = fields.Bool(
+        required=True,
+        description=f"Proofread status of the axon only. True indicates axon is at least clean.",
+    )
+    strategy_dendrite = fields.String(
+        required=True,
+        description=f"Strategy used when proofreading dendrite. See table description for more details.",
+    )
+    strategy_axon = fields.String(
+        required=True,
+        description=f"Strategy used when proofreading axon. See table description for more details.",
+    )


### PR DESCRIPTION
add schema with proofreading status (bool) and strategy (str) for each neuron compartment. Also adds a schema with spatial point, boolean, and numeric field for the valid root id. 