### PR TITLE
Implementing Synapse Annotations From Existing Schema 

### DIFF
--- a/emannotationschemas/schemas/synapse.py
+++ b/emannotationschemas/schemas/synapse.py
@@ -92,3 +92,22 @@ class ValidSynapse(ReferenceAnnotation):
         required=True,
         description="Valid annotation for synapses",
     )
+
+# Adding classes from https://github.com/aplbrain/BENCHMARK-Metadata/blob/1.1-and-1.2-annotation-metadata-for-review/annotation-metadata/CAVE-implemented-annotation-metadata-version-1.2.plantuml
+# With explanations from here: https://github.com/aplbrain/BENCHMARK-Metadata/blob/1.1-and-1.2-annotation-metadata-for-review/annotation-metadata/required-field-names.md
+class Chemical(BaseSynapseSchema):
+        presynaptic = mm.fields.Float(
+        description="Specialized sites that transmit signals between presynaptic neurons and their respective postsynaptic targets"
+    )
+        postsynaptic = mm.fields.Float(
+        description="Specialized sites that transmit signals between presynaptic neurons and their respective postsynaptic targets"
+    )
+        
+class Electrical(BaseSynapseSchema):
+        gap_junction_location = mm.fields.Float(
+        description="The location where channels that allow for cell to cell transfers between ions and small molecules"
+    )
+        gap_junction_id = mm.fields.Float(
+        description="The identification tag for gap junctions"
+    )
+        


### PR DESCRIPTION
Integrating synapse-related annotations from [existing schema format](https://github.com/aplbrain/BENCHMARK-Metadata/blob/1.1-and-1.2-annotation-metadata-for-review/annotation-metadata/required-field-names.md). 

For each data entry, the fields and general information can be pulled from the corresponding tables. Here is an example format for a data entry: 

<img width="555" alt="Screenshot 2024-07-29 at 5 41 56 PM" src="https://github.com/user-attachments/assets/1585f101-b660-41ff-8800-0f11cc04ae89">
